### PR TITLE
컴포넌트 분리, 독후감 수정/도서 검색 페이지 완성

### DIFF
--- a/frontend/.eslintrc.js
+++ b/frontend/.eslintrc.js
@@ -44,7 +44,7 @@ module.exports = {
 		'import/resolver': {
 			node: {
 				extensions: ['.js', '.jsx', '.ts', '.tsx'],
-				paths: ['./src'],
+				paths: ['src'],
 			},
 		},
 	},

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,7 +15,7 @@
     "react-router-dom": "5.2.0",
     "react-scripts": "4.0.3",
     "sass": "1.35.2",
-    "use-react-router": "1.0.7",
+    "use-react-router": "^1.0.7",
     "web-vitals": "1.1.2"
   },
   "scripts": {

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -24,10 +24,13 @@ function App() {
 			<Route exact path="/" component={Home} />
 			<Route path="/login" component={Login} />
 			<Route path="/join" component={Join} />
-			<Route path="/mypage" component={MyPage} />
-			<Route exact path="/report" component={Report} />
-			<Route exact path="/report/:id" component={ReportInfo} />
-			<Route exact path="/report/:id/edit" component={ReportWrite} />
+			<Switch>
+				<Route path="/mypage/edit" component={UserEdit} />
+				<Route exact path="/mypage" component={MyPage} />
+				<Route path="/report/:id/edit" component={ReportWrite} />
+				<Route path="/report/:id" component={ReportInfo} />
+				<Route exact path="/report" component={Report} />
+			</Switch>
 			<Route exact path="/mylib" component={MyLibrary} />
 			<Route exact path="/book_info/:id" component={BookInfo} />
 			<Route path="/calendar" component={BookCalendar} />

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1,7 +1,19 @@
 import React from 'react';
 import { Route, Switch } from 'react-router-dom';
 import { Grid } from '@material-ui/core';
-import { Home, Login, Join, MyPage, Report, UserEdit, MyLibrary, BookCalendar, BookInfo } from './pages';
+import {
+	Home,
+	Login,
+	Join,
+	MyPage,
+	Report,
+	ReportInfo,
+	ReportWrite,
+	UserEdit,
+	MyLibrary,
+	BookCalendar,
+	BookInfo,
+} from './pages';
 import { Header } from './components';
 import './scss/main.scss';
 
@@ -13,7 +25,9 @@ function App() {
 			<Route path="/login" component={Login} />
 			<Route path="/join" component={Join} />
 			<Route path="/mypage" component={MyPage} />
-			<Route path="/report" component={Report} />
+			<Route exact path="/report" component={Report} />
+			<Route exact path="/report/:id" component={ReportInfo} />
+			<Route exact path="/report/:id/edit" component={ReportWrite} />
 			<Route exact path="/mylib" component={MyLibrary} />
 			<Route exact path="/book_info/:id" component={BookInfo} />
 			<Route path="/calendar" component={BookCalendar} />

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -13,6 +13,7 @@ import {
 	MyLibrary,
 	BookCalendar,
 	BookInfo,
+	Search,
 } from './pages';
 import { Header } from './components';
 import './scss/main.scss';
@@ -34,6 +35,7 @@ function App() {
 			<Route exact path="/mylib" component={MyLibrary} />
 			<Route exact path="/book_info/:id" component={BookInfo} />
 			<Route path="/calendar" component={BookCalendar} />
+			<Route path="/search" component={Search} />
 		</Grid>
 	);
 }

--- a/frontend/src/components/BookList.js
+++ b/frontend/src/components/BookList.js
@@ -1,0 +1,32 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+import { Grid, Button, Paper } from '@material-ui/core';
+
+const BookList = ({ itemData, path }) => {
+	return (
+		<Grid container spacing={2} className="booklist" align="center">
+			{itemData.map((item) => (
+				<Grid item xs={4} className="bookCard">
+					<Link
+						to={{
+							pathname: `${path}${item.id}`,
+							state: item,
+						}}
+					>
+						<Button>
+							<Paper className="bookcard-paper">
+								<img className="image" src={item.img} alt="title" />
+								<Grid container className="binfo-typo">
+									<Grid>{item.title}</Grid>
+									<Grid>{item.author}</Grid>
+								</Grid>
+							</Paper>
+						</Button>
+					</Link>
+				</Grid>
+			))}
+		</Grid>
+	);
+};
+
+export default BookList;

--- a/frontend/src/components/RoundButton.js
+++ b/frontend/src/components/RoundButton.js
@@ -1,0 +1,17 @@
+import React from 'react';
+import { Button } from '@material-ui/core';
+
+const RoundButton = ({ backColor, textColor, text }) => {
+	const styles = {
+		borderRadius: 20,
+		backgroundColor: backColor ? `${backColor}` : '#fdd45a',
+		color: textColor ? `${textColor}` : '#ffffff',
+	};
+	return (
+		<Button style={styles} variant="contained">
+			{text}
+		</Button>
+	);
+};
+
+export default RoundButton;

--- a/frontend/src/components/SearchBar.js
+++ b/frontend/src/components/SearchBar.js
@@ -1,0 +1,39 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+import { Grid, Paper, InputBase } from '@material-ui/core';
+import SearchIcon from '@material-ui/icons/Search';
+import IconButton from '@material-ui/core/IconButton';
+
+const SearchBar = ({ title }) => {
+	return (
+		<Grid container className="search-container">
+			<Paper
+				component="form"
+				className="home-search"
+				style={{
+					borderRadius: 20,
+					backgroundColor: '#fdd45a',
+				}}
+				variant="contained"
+			>
+				<Grid className="search-input">
+					<InputBase placeholder="원하는 책을 검색해보세요!" inputProps={{ 'aria-label': 'search' }} />
+				</Grid>
+				<Grid className="search-icon">
+					<Link
+						to={{
+							pathname: `search/${title}`,
+							state: title,
+						}}
+					>
+						<IconButton aria-label="search">
+							<SearchIcon />
+						</IconButton>
+					</Link>
+				</Grid>
+			</Paper>
+		</Grid>
+	);
+};
+
+export default SearchBar;

--- a/frontend/src/components/SubHeader.js
+++ b/frontend/src/components/SubHeader.js
@@ -1,0 +1,14 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+import { Grid, Button, Paper } from '@material-ui/core';
+
+const SubHeader = ({ name }) => {
+	return (
+		<Grid container>
+			<Grid className="subheader">{name}</Grid>
+			<Grid className="subheader-line" />
+		</Grid>
+	);
+};
+
+export default SubHeader;

--- a/frontend/src/components/index.js
+++ b/frontend/src/components/index.js
@@ -4,3 +4,4 @@ export { default as Calendar } from './Calendar';
 export { default as BookList } from './BookList';
 export { default as SubHeader } from './SubHeader';
 export { default as RoundButton } from './RoundButton';
+export { default as SearchBar } from './SearchBar';

--- a/frontend/src/components/index.js
+++ b/frontend/src/components/index.js
@@ -1,3 +1,6 @@
 export { default as Header } from './Header';
 export { default as CalendarHeader } from './CalendarHeader';
 export { default as Calendar } from './Calendar';
+export { default as BookList } from './BookList';
+export { default as SubHeader } from './SubHeader';
+export { default as RoundButton } from './RoundButton';

--- a/frontend/src/pages/Home.js
+++ b/frontend/src/pages/Home.js
@@ -1,34 +1,15 @@
 import React from 'react';
-import { Avatar, Button, Grid, Paper, Link, Typography, InputBase } from '@material-ui/core';
-import SearchIcon from '@material-ui/icons/Search';
-import IconButton from '@material-ui/core/IconButton';
+import { Avatar, Button, Grid, Paper, Typography, InputBase } from '@material-ui/core';
+import SearchBar from '../components/SearchBar';
 import ChatChar from '../components/styles/chat_character.jpeg';
 import UserChar from '../components/styles/user_character.png';
 import InitCalendar from '../components/styles/calendar.PNG';
 
 function Home() {
+	const title = '달러구트 꿈 백화점';
 	return (
 		<Grid container className="home">
-			<Grid container className="search-container">
-				<Paper
-					component="form"
-					className="home-search"
-					style={{
-						borderRadius: 20,
-						backgroundColor: '#fdd45a',
-					}}
-					variant="contained"
-				>
-					<Grid className="search-input">
-						<InputBase placeholder="원하는 책을 검색해보세요!" inputProps={{ 'aria-label': 'search' }} />
-					</Grid>
-					<Grid className="search-icon">
-						<IconButton aria-label="search">
-							<SearchIcon />
-						</IconButton>
-					</Grid>
-				</Paper>
-			</Grid>
+			<SearchBar title={title} />
 			<Grid container direction="column" className="calendar-container">
 				<Paper elevation={3} className="home-calendar">
 					<img src={InitCalendar} alt="cal" />

--- a/frontend/src/pages/MyLibrary.js
+++ b/frontend/src/pages/MyLibrary.js
@@ -1,9 +1,7 @@
 import React from 'react';
-import { Grid, Button, Paper } from '@material-ui/core';
-import { Link } from 'react-router-dom';
-
-import DeleteOutlineIcon from '@material-ui/icons/DeleteOutline';
-import ArtTrackIcon from '@material-ui/icons/ArtTrack';
+import { Grid } from '@material-ui/core';
+import BookList from '../components/BookList';
+import SubHeader from '../components/SubHeader';
 
 const itemData = [
 	{
@@ -72,32 +70,8 @@ function MyLibrary() {
 	return (
 		<Grid align="center" className="mylibrary">
 			<Grid align="center" className="mylibrary-container">
-				<Grid container className="library-typo">
-					OO 님의 서재
-				</Grid>
-				<Grid className="library-line" />
-				<Grid container spacing={2} className="booklist" align="center">
-					{itemData.map((item) => (
-						<Grid item xs={4} className="bookCard">
-							<Link
-								to={{
-									pathname: `/book_info/${item.id}`,
-									state: item,
-								}}
-							>
-								<Button>
-									<Paper className="bookcard-paper">
-										<img className="image" src={item.img} alt="title" />
-										<Grid container className="binfo-typo">
-											<Grid>{item.title}</Grid>
-											<Grid>{item.author}</Grid>
-										</Grid>
-									</Paper>
-								</Button>
-							</Link>
-						</Grid>
-					))}
-				</Grid>
+				<SubHeader name="내 서재" />
+				<BookList itemData={itemData} path="/book_info/" />
 			</Grid>
 		</Grid>
 	);

--- a/frontend/src/pages/MyPage.js
+++ b/frontend/src/pages/MyPage.js
@@ -1,107 +1,92 @@
 import React from 'react';
-import { Grid, Typography, Paper, Button, Avatar, Link } from '@material-ui/core';
+import { Grid, Typography, Paper, Button, Avatar } from '@material-ui/core';
+import { Link } from 'react-router-dom';
 import GoodStamp from '../components/styles/good_stamp.png';
 import ThumbStamp from '../components/styles/thumb_stamp.PNG';
 import BookList from '../components/styles/book_list.jpg';
-import UserEdit from './UserEdit';
+import RoundButton from '../components/RoundButton';
 
 function MyPage() {
-	const move = () => {
-		window.location.href = '/mypage/edit';
-	};
 	return (
 		<Grid container className="mypage" maxWidth="xs">
-			{window.location.pathname === '/mypage/edit' ? (
-				<UserEdit />
-			) : (
-				<Grid container>
-					<Grid container direction="column" className="mypage-left">
-						<Paper elevation={2} className="book-title">
-							캐릭터가 자랄 수 있게 책을 읽어봐요
-						</Paper>
-						<Grid className="book-paper">
-							<img src={BookList} width="300" height="400" alt="booklist" />
-						</Grid>
-					</Grid>
-
-					<Grid container className="mypage-right">
-						<Typography variant="h5" className="profile-title">
-							내 정보 관리
-						</Typography>
-						<Grid container className="profile-container">
-							<Button>
-								<Paper
-									style={{
-										borderRadius: 20,
-										backgroundColor: '#fdd45a',
-									}}
-									elevation={3}
-									className="profile-paper"
-								>
-									<Avatar className="profile" />
-									<Grid container direction="column" align="start" className="profile-name">
-										<Typography
-											variant="h7"
-											style={{
-												color: '#ffffff',
-											}}
-										>
-											Lv.1 독서 새싹
-										</Typography>
-										<Typography variant="h7" className="name">
-											사용자님
-										</Typography>
-									</Grid>
-									<Link to="/mypage/edit">
-										<Button
-											style={{
-												borderRadius: 15,
-												backgroundColor: '#ffffff',
-											}}
-											className="profile-btn"
-											onClick={move}
-										>
-											수정
-										</Button>
-									</Link>
-								</Paper>
-							</Button>
-						</Grid>
-						<Typography variant="h5" className="profile-title">
-							보유 뱃지
-						</Typography>
-						<Grid container className="profile-container">
-							<Button>
-								<Paper
-									style={{
-										borderRadius: 20,
-										backgroundColor: '#fdd45a',
-									}}
-									elevation={3}
-									className="profile-paper"
-								>
-									<Grid container direction="column" align="center">
-										<Grid align="center">
-											<Avatar src={GoodStamp} className="badge" />
-										</Grid>
-										<Typography variant="h7" className="badge-name">
-											참 잘했어요!
-										</Typography>
-									</Grid>
-									<Grid container direction="column" align="center">
-										<Grid align="center">
-											<Avatar src={ThumbStamp} className="badge" />
-										</Grid>
-										<Typography variant="h7" className="badge-name">
-											베스트셀러 수집가
-										</Typography>
-									</Grid>
-								</Paper>
-							</Button>
-						</Grid>
+			<Grid container>
+				<Grid container direction="column" className="mypage-left">
+					<Paper elevation={2} className="book-title">
+						캐릭터가 자랄 수 있게 책을 읽어봐요
+					</Paper>
+					<Grid className="book-paper">
+						<img src={BookList} width="300" height="400" alt="booklist" />
 					</Grid>
 				</Grid>
-			)}
+
+				<Grid container className="mypage-right">
+					<Typography variant="h5" className="profile-title">
+						내 정보 관리
+					</Typography>
+					<Grid container className="profile-container">
+						<Button>
+							<Paper
+								style={{
+									borderRadius: 20,
+									backgroundColor: '#fdd45a',
+								}}
+								elevation={3}
+								className="profile-paper"
+							>
+								<Avatar className="profile" />
+								<Grid container direction="column" align="start" className="profile-name">
+									<Typography
+										variant="h7"
+										style={{
+											color: '#ffffff',
+										}}
+									>
+										Lv.1 독서 새싹
+									</Typography>
+									<Typography variant="h7" className="name">
+										사용자님
+									</Typography>
+								</Grid>
+								<Link to="/mypage/edit">
+									<RoundButton backColor="#ffffff" textColor="#000000" text="수정" />
+								</Link>
+							</Paper>
+						</Button>
+					</Grid>
+					<Typography variant="h5" className="profile-title">
+						보유 뱃지
+					</Typography>
+					<Grid container className="profile-container">
+						<Button>
+							<Paper
+								style={{
+									borderRadius: 20,
+									backgroundColor: '#fdd45a',
+								}}
+								elevation={3}
+								className="profile-paper"
+							>
+								<Grid container direction="column" align="center">
+									<Grid align="center">
+										<Avatar src={GoodStamp} className="badge" />
+									</Grid>
+									<Typography variant="h7" className="badge-name">
+										참 잘했어요!
+									</Typography>
+								</Grid>
+								<Grid container direction="column" align="center">
+									<Grid align="center">
+										<Avatar src={ThumbStamp} className="badge" />
+									</Grid>
+									<Typography variant="h7" className="badge-name">
+										베스트셀러 수집가
+									</Typography>
+								</Grid>
+							</Paper>
+						</Button>
+					</Grid>
+				</Grid>
+			</Grid>
 		</Grid>
 	);
 }

--- a/frontend/src/pages/Report.js
+++ b/frontend/src/pages/Report.js
@@ -3,6 +3,7 @@ import { Grid, Button } from '@material-ui/core';
 import { Link } from 'react-router-dom';
 import SubHeader from '../components/SubHeader';
 import BookList from '../components/BookList';
+import { RoundButton } from '../components';
 
 const itemData = [
 	{
@@ -48,22 +49,9 @@ function Report() {
 			<Grid align="center" className="report-container">
 				<SubHeader name="독후감" />
 				<BookList itemData={itemData} path="/report/" />
-				<Link
-					to={{
-						pathname: '/report/edit',
-					}}
-				>
-					<Button
-						style={{
-							borderRadius: 20,
-							backgroundColor: '#fdd45a',
-							color: '#ffffff',
-						}}
-						variant="contained"
-					>
-						작성
-					</Button>
-				</Link>
+				<Grid align="end">
+					<RoundButton text="작성" />
+				</Grid>
 			</Grid>
 		</Grid>
 	);

--- a/frontend/src/pages/Report.js
+++ b/frontend/src/pages/Report.js
@@ -1,67 +1,69 @@
 import React from 'react';
-import { Route } from 'react-router-dom';
-import { Grid, Paper, Link, Button } from '@material-ui/core';
-import ReportInfo from './ReportInfo';
-import dream from '../components/styles/dream.jpg';
-import amond from '../components/styles/amond.jpg';
-import midnight from '../components/styles/midnight.jpg';
+import { Grid, Button } from '@material-ui/core';
+import { Link } from 'react-router-dom';
+import SubHeader from '../components/SubHeader';
+import BookList from '../components/BookList';
 
-function FormRow() {
-	const move = () => {
-		window.location.href = '/report/info';
-	};
-	return (
-		<>
-			<Grid item xs={4}>
-				<Button onClick={move}>
-					<Paper className="report-paper">
-						<img className="image" src={midnight} alt="title" />
-					</Paper>
-				</Button>
-				<Grid className="report-name">미드나잇 라이브러리</Grid>
-			</Grid>
-			<Grid item xs={4}>
-				<Button onClick={move}>
-					<Paper className="report-paper">
-						<img className="image" src={amond} alt="title" />
-					</Paper>
-				</Button>
-				<Grid className="report-name">아몬드</Grid>
-			</Grid>
-			<Grid item xs={4}>
-				<Button onClick={move}>
-					<Paper className="report-paper">
-						<img className="image" src={dream} alt="title" />
-					</Paper>
-				</Button>
-				<Grid className="report-name">달러구트 꿈 백화점</Grid>
-			</Grid>
-		</>
-	);
-}
+const itemData = [
+	{
+		id: 1,
+		img: 'http://image.kyobobook.co.kr/images/book/xlarge/556/x9791191056556.jpg',
+		title: '미드나잇 라이브러리',
+		author: '매트 헤이그',
+	},
+	{
+		id: 2,
+		img: 'http://image.kyobobook.co.kr/images/book/xlarge/267/x9788936434267.jpg',
+		title: '아몬드',
+		author: '손원평',
+	},
+	{
+		id: 3,
+		img: 'https://www.readersnews.com/news/photo/202009/100406_67647_654.jpg',
+		title: '달러구트 꿈 백화점',
+		author: '이미예',
+	},
+	{
+		id: 4,
+		img: 'http://image.kyobobook.co.kr/images/book/xlarge/018/x9791190090018.jpg',
+		title: '우리가 빛의 속도로 갈 수 없다면',
+		author: '김연수',
+	},
+	{
+		id: 5,
+		img: 'https://img.hankyung.com/photo/201603/BA.11350864.1.jpg',
+		title: '주토피아',
+		author: '@joody',
+	},
+	{
+		id: 6,
+		img: 'https://www.puzzlesarang.com/shop/data/goods/1563264794714m0.jpg',
+		title: '신데렐라',
+		author: 'cinderella',
+	},
+];
 function Report() {
 	return (
-		<Grid container align="center" className="report">
-			<Grid container align="center" className="report-container">
-				<Grid container className="report-typo">
-					독후감 갤러리
-				</Grid>
-				<Grid className="report-line" />
-				{window.location.pathname === '/report/info' ? (
-					<ReportInfo />
-				) : (
-					<Grid container className="report-grid" spacing={4}>
-						<Grid container item xs={14} spacing={4}>
-							<FormRow />
-						</Grid>
-						<Grid container item xs={14} spacing={4}>
-							<FormRow />
-						</Grid>
-						<Grid container item xs={14} spacing={4}>
-							<FormRow />
-						</Grid>
-					</Grid>
-				)}
+		<Grid align="center" className="report">
+			<Grid align="center" className="report-container">
+				<SubHeader name="독후감" />
+				<BookList itemData={itemData} path="/report/" />
+				<Link
+					to={{
+						pathname: '/report/edit',
+					}}
+				>
+					<Button
+						style={{
+							borderRadius: 20,
+							backgroundColor: '#fdd45a',
+							color: '#ffffff',
+						}}
+						variant="contained"
+					>
+						작성
+					</Button>
+				</Link>
 			</Grid>
 		</Grid>
 	);

--- a/frontend/src/pages/ReportInfo.js
+++ b/frontend/src/pages/ReportInfo.js
@@ -1,46 +1,52 @@
 import React from 'react';
-import { Grid, Paper, Link, Button } from '@material-ui/core';
-import dream from '../components/styles/dream.jpg';
-import amond from '../components/styles/amond.jpg';
-import midnight from '../components/styles/midnight.jpg';
+import { Grid, Paper, Button } from '@material-ui/core';
+import useReactRouter from 'use-react-router';
+import { Link } from 'react-router-dom';
+import { RoundButton } from '../components';
 
-function FormRow() {
-	return (
-		<>
-			<Grid container className="info-grid" item xs={4}>
-				<Paper className="info-paper">
-					<img className="image" src={midnight} alt="title" />
-				</Paper>
-			</Grid>
-		</>
-	);
-}
 function ReportInfo() {
+	const { location } = useReactRouter();
+	const imgurl = location.state.img;
+	const { title } = location.state;
 	const styles = {
-		width: 80,
-		height: 45,
-		fontSize: 18,
-		fontWeight: 'bold',
-		borderRadius: 20,
+		title: {
+			width: 80,
+			height: 45,
+			fontSize: 18,
+			fontWeight: 'bold',
+			borderRadius: 20,
+		},
 	};
 	return (
 		<Grid container className="reportinfo">
 			<Grid container className="info-grid">
-				<FormRow />
+				<Paper className="info-paper">
+					<img className="image" src={imgurl} alt="title" />
+				</Paper>
 			</Grid>
-			<Grid container direction="column" className="info-des">
+			<Grid align="center" direction="column" className="info-des">
 				<Grid container className="info">
-					<Button style={styles}>제목</Button>
-					<Grid className="info-text">달러구트 꿈 백화점</Grid>
+					<Button style={styles.title}>제목</Button>
+					<Grid className="info-text">{title}</Grid>
 				</Grid>
 				<Grid container className="info">
-					<Button style={styles}>내용</Button>
+					<Button style={styles.title}>내용</Button>
 					<Grid className="info-text">꿈을 사는 이야기</Grid>
 				</Grid>
 				<Grid container className="info-box">
 					<Paper elevation={2} className="info-box-paper">
 						느낀점:
 					</Paper>
+					<Grid container className="info-edit">
+						<Link
+							to={{
+								pathname: `${location.state.id}/edit`,
+								state: location.state,
+							}}
+						>
+							<RoundButton text="수정" />
+						</Link>
+					</Grid>
 				</Grid>
 			</Grid>
 		</Grid>

--- a/frontend/src/pages/ReportWrite.js
+++ b/frontend/src/pages/ReportWrite.js
@@ -3,6 +3,7 @@ import { Grid, Paper, Button, TextField } from '@material-ui/core';
 import useReactRouter from 'use-react-router';
 import { Link } from 'react-router-dom';
 import PhotoCameraIcon from '@material-ui/icons/PhotoCamera';
+import { RoundButton } from '../components';
 
 function ReportWrite() {
 	const { location } = useReactRouter();
@@ -15,11 +16,6 @@ function ReportWrite() {
 			fontSize: 18,
 			fontWeight: 'bold',
 			borderRadius: 20,
-		},
-		button: {
-			borderRadius: 20,
-			backgroundColor: '#fdd45a',
-			color: '#ffffff',
 		},
 	};
 	return (
@@ -50,9 +46,7 @@ function ReportWrite() {
 								state: location.state,
 							}}
 						>
-							<Button style={styles.button} variant="contained">
-								확인
-							</Button>
+							<RoundButton text="확인" />
 						</Link>
 					</Grid>
 				</Grid>

--- a/frontend/src/pages/ReportWrite.js
+++ b/frontend/src/pages/ReportWrite.js
@@ -1,0 +1,63 @@
+import React from 'react';
+import { Grid, Paper, Button, TextField } from '@material-ui/core';
+import useReactRouter from 'use-react-router';
+import { Link } from 'react-router-dom';
+import PhotoCameraIcon from '@material-ui/icons/PhotoCamera';
+
+function ReportWrite() {
+	const { location } = useReactRouter();
+	const imgurl = location.state.img;
+	const { title } = location.state;
+	const styles = {
+		title: {
+			width: 80,
+			height: 45,
+			fontSize: 18,
+			fontWeight: 'bold',
+			borderRadius: 20,
+		},
+		button: {
+			borderRadius: 20,
+			backgroundColor: '#fdd45a',
+			color: '#ffffff',
+		},
+	};
+	return (
+		<Grid container className="reportinfo">
+			<Grid container className="info-grid">
+				<Paper className="info-paper">
+					<img className="image" src={imgurl} alt="title" />
+				</Paper>
+				<Button startIcon={<PhotoCameraIcon />} />
+			</Grid>
+			<Grid align="center" direction="column" className="info-des">
+				<Grid container className="info">
+					<Button style={styles.title}>제목</Button>
+					<TextField className="info-text" defaultValue={title} />
+				</Grid>
+				<Grid container className="info">
+					<Button style={styles.title}>내용</Button>
+					<TextField defaultValue="꿈을 사는 이야기" />
+				</Grid>
+				<Grid container className="info-box">
+					<Paper elevation={2} className="info-box-paper">
+						<TextField variant="outlined" fullWidth defaultValue="느낀점" multiline max rows={14} />
+					</Paper>
+					<Grid container className="info-edit">
+						<Link
+							to={{
+								pathname: `/report/${location.state.id}`,
+								state: location.state,
+							}}
+						>
+							<Button style={styles.button} variant="contained">
+								확인
+							</Button>
+						</Link>
+					</Grid>
+				</Grid>
+			</Grid>
+		</Grid>
+	);
+}
+export default ReportWrite;

--- a/frontend/src/pages/Search.js
+++ b/frontend/src/pages/Search.js
@@ -1,0 +1,81 @@
+import React from 'react';
+import { Grid } from '@material-ui/core';
+import BookList from '../components/BookList';
+import SubHeader from '../components/SubHeader';
+import SearchBar from '../components/SearchBar';
+
+const itemData = [
+	{
+		id: 1,
+		img: 'https://cdn.pixabay.com/photo/2018/01/10/23/53/rabbit-3075088_960_720.png',
+		title: '토끼의 하루',
+		author: 'dok2',
+	},
+	{
+		id: 2,
+		img: 'https://www.fashionn.com/files/board/2015/image/p19r7o9qe1av7a681aapaaj1com1.jpg',
+		title: '인사이드 아웃',
+		author: '기쁨이',
+	},
+	{
+		id: 3,
+		img: 'http://image.kyobobook.co.kr/images/book/xlarge/453/x9788967356453.jpg',
+		title: '심슨 가족이 사는 법',
+		author: '@Simpsons',
+	},
+	{
+		id: 4,
+		img: 'http://image.kyobobook.co.kr/images/book/xlarge/018/x9791190090018.jpg',
+		title: '우리가 빛의 속도로 갈 수 없다면',
+		author: '김연수',
+	},
+	{
+		id: 5,
+		img: 'https://www.readersnews.com/news/photo/202009/100406_67647_654.jpg',
+		title: '달러구트 꿈 백화점',
+		author: '이미예',
+	},
+	{
+		id: 6,
+		img: 'http://image.kyobobook.co.kr/images/book/xlarge/596/x9791187192596.jpg',
+		title: '어린왕자',
+		author: '생택쥐베리',
+	},
+	{
+		id: 7,
+		img: 'https://image.aladin.co.kr/product/788/3/cover500/8958284870_1.jpg',
+		title: '누가 내 머리에 똥 쌌어?',
+		author: 'who',
+	},
+	{
+		id: 8,
+		img: 'https://img.hankyung.com/photo/201603/BA.11350864.1.jpg',
+		title: '주토피아',
+		author: '@joody',
+	},
+	{
+		id: 9,
+		img: 'http://img2.tmon.kr/cdn3/deals/2020/06/03/3656253742/original_3656253742_front_e6213_1591150707production.jpg',
+		title: '흥부와 놀부',
+		author: 'heungbuandnolbu',
+	},
+	{
+		id: 10,
+		img: 'https://www.puzzlesarang.com/shop/data/goods/1563264794714m0.jpg',
+		title: '신데렐라',
+		author: 'cinderella',
+	},
+];
+
+function Search() {
+	return (
+		<Grid align="center" className="mylibrary">
+			<Grid align="center" className="mylibrary-container">
+				<SearchBar title={itemData[0].title} />
+				<SubHeader name="도서 검색" />
+				<BookList itemData={itemData} path="/book_info/" />
+			</Grid>
+		</Grid>
+	);
+}
+export default Search;

--- a/frontend/src/pages/index.js
+++ b/frontend/src/pages/index.js
@@ -9,3 +9,4 @@ export { default as UserEdit } from './UserEdit';
 export { default as MyLibrary } from './MyLibrary';
 export { default as BookCalendar } from './BookCalendar';
 export { default as BookInfo } from './BookInfo';
+export { default as Search } from './Search';

--- a/frontend/src/pages/index.js
+++ b/frontend/src/pages/index.js
@@ -4,6 +4,7 @@ export { default as Login } from './Login';
 export { default as MyPage } from './MyPage';
 export { default as Report } from './Report';
 export { default as ReportInfo } from './ReportInfo';
+export { default as ReportWrite } from './ReportWrite';
 export { default as UserEdit } from './UserEdit';
 export { default as MyLibrary } from './MyLibrary';
 export { default as BookCalendar } from './BookCalendar';

--- a/frontend/src/scss/components/_booklist.scss
+++ b/frontend/src/scss/components/_booklist.scss
@@ -1,0 +1,25 @@
+.booklist {
+  width: 100%;
+  .bookCard {
+    margin-top: 20px;
+    .bookcard-paper {
+      width: 230px;
+      height: 230px;
+      display: flex;
+      flex-direction: column;
+      justify-content: center;
+      align-items: center;
+      text-align: center;
+      .image {
+        width: 60%;
+        height: 80%;
+        display: flex;
+        justify-content: center;
+      }
+      .binfo-typo {
+        display: flex;
+        flex-direction: column;
+      }
+    }
+  }
+}

--- a/frontend/src/scss/components/_searchbar.scss
+++ b/frontend/src/scss/components/_searchbar.scss
@@ -1,0 +1,19 @@
+.search-container {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  margin: 15px;
+  .home-search {
+    width: 300px;
+    padding: 2px 10px;
+    display: flex;
+    align-items: center;
+    .search-input {
+      margin-left: 15px;
+    }
+    .search-icon {
+      margin-left: 50px;
+      color: green;
+    }
+  }
+}

--- a/frontend/src/scss/components/_subheader.scss
+++ b/frontend/src/scss/components/_subheader.scss
@@ -1,0 +1,10 @@
+.subheader {
+  font-size: 1.4rem;
+  font-weight: 600;
+  margin-bottom: 10px;
+}
+.subheader-line {
+  margin: 0 0 10px 0;
+  width: 100%;
+  border-bottom: 2.5px double $yellow;
+}

--- a/frontend/src/scss/main.scss
+++ b/frontend/src/scss/main.scss
@@ -5,6 +5,8 @@
 
 // components
 @import './components/header';
+@import './components/subheader';
+@import './components/booklist';
 
 // pages
 @import './pages/home';

--- a/frontend/src/scss/main.scss
+++ b/frontend/src/scss/main.scss
@@ -7,6 +7,7 @@
 @import './components/header';
 @import './components/subheader';
 @import './components/booklist';
+@import './components/searchbar';
 
 // pages
 @import './pages/home';

--- a/frontend/src/scss/pages/_home.scss
+++ b/frontend/src/scss/pages/_home.scss
@@ -1,23 +1,4 @@
 .home {
-  .search-container {
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    margin: 15px;
-    .home-search {
-      width: 300px;
-      padding: 2px 10px;
-      display: flex;
-      align-items: center;
-      .search-input {
-        margin-left: 15px;
-      }
-      .search-icon {
-        margin-left: 50px;
-        color: green;
-      }
-    }
-  }
   .calendar-container {
     width: 50%;
     display: flex;

--- a/frontend/src/scss/pages/_mylibrary.scss
+++ b/frontend/src/scss/pages/_mylibrary.scss
@@ -1,45 +1,6 @@
-.mylibrary{
-    margin-top: 30px;
-    .mylibrary-container{
-        width: 60%;
-        .library-typo {
-            font-size: 1.4rem;
-            font-weight: 600;
-            margin-top: 10px;
-            margin-bottom: 10px;
-          }
-          .library-line {
-            margin: 0 0 10px 0;
-            width: 100%;
-            border-bottom: 2.5px double $yellow;
-          }
-        .booklist{
-            width: 100%;
-            .bookCard{
-                margin-top: 20px;
-    
-                .bookcard-paper{
-                    width: 230px;
-                    height: 230px;
-                    display: flex;
-                    flex-direction: column;
-                    justify-content: center;
-                    align-items: center;
-                    text-align: center;
-                    .image {
-                        width: 60%;
-                        height:80%;
-                        display: flex;
-                        justify-content: center;
-                    }
-                    .binfo-typo{
-                        display: flex;
-                        flex-direction: column;
-                    }
-                }
-            }
-        }
-    }
-    
-    
+.mylibrary {
+  margin-top: 30px;
+  .mylibrary-container {
+    width: 60%;
+  }
 }

--- a/frontend/src/scss/pages/_report.scss
+++ b/frontend/src/scss/pages/_report.scss
@@ -1,38 +1,6 @@
 .report {
-  display: flex;
-  justify-content: center;
-  margin-top: 15px;
+  margin-top: 30px;
   .report-container {
     width: 60%;
-    .report-typo {
-      font-size: 1.4rem;
-      font-weight: 600;
-      margin-top: 10px;
-      margin-bottom: 10px;
-    }
-    .report-line {
-      margin: 0 0 10px 0;
-      width: 100%;
-      border-bottom: 2.5px double $yellow;
-    }
-    .report-grid {
-      margin-top: 20px;
-    }
-
-    .report-name {
-      margin-top: 10px;
-      font-weight: 800;
-    }
-    .report-paper {
-      width: 230px;
-      height: 230px;
-      display: flex;
-      justify-content: center;
-      text-align: center;
-      .image {
-        display: flex;
-        justify-content: center;
-      }
-    }
   }
 }

--- a/frontend/src/scss/pages/_reportinfo.scss
+++ b/frontend/src/scss/pages/_reportinfo.scss
@@ -1,4 +1,6 @@
 .reportinfo {
+  display: flex;
+  justify-content: center;
   .info-grid {
     display: flex;
     justify-content: center;
@@ -16,8 +18,7 @@
     }
   }
   .info-des {
-    display: flex;
-    justify-content: center;
+    width: 60%;
     margin-top: 20px;
     padding: 0 20px 0 20px;
     .info {
@@ -40,6 +41,15 @@
         padding: 60px;
         margin: 25px;
         font-size: 1.2rem;
+      }
+      .info-box-edit {
+        width: 100%;
+        height: 200px;
+      }
+      .info-edit {
+        display: flex;
+        justify-content: flex-end;
+        margin: 0 20px 20px 0;
       }
     }
   }


### PR DESCRIPTION
- 독후감, 내 서재, 도서 검색에서 쓰는 Header를 SubHeader로 분리했습니다.
- 위 페이지들에서 쓰는 n x n 그리드를 BookList로 분리했습니다.
- 자주 쓰는 버튼을 RoundButton으로 분리하고 backColor, textColor, text를 인자로 전달할 수 있게 했습니다.
(전달하지 않으면 기본값인 노란 배경에 하얀 글자로 설정됨)

> 도서 검색 페이지의 버튼을 클릭하면 search url이 계속 쌓이는 이슈가 있습니다.